### PR TITLE
Loosen image_optim dependency

### DIFF
--- a/paperclip-optimizer.gemspec
+++ b/paperclip-optimizer.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.license       = 'MIT'
 
   spec.add_runtime_dependency 'paperclip', '>= 3.4'
-  spec.add_runtime_dependency 'image_optim', '~> 0.19.0'
+  spec.add_runtime_dependency 'image_optim', '~> 0.19'
 
   spec.add_development_dependency 'bundler', '~> 1.3'
   spec.add_development_dependency 'rake', '~> 10.1'


### PR DESCRIPTION
Due to a issue with Ruby 2.2 and image_optim 0.19. To work with ruby 2.2, image_optim 0.20.2 is required.

This loosens the dependency.