### PR TITLE
Solve erratic "Errno::ENOENT: No such file or directory" on the fileutils.rb stat method

### DIFF
--- a/lib/paperclip-optimizer/processor.rb
+++ b/lib/paperclip-optimizer/processor.rb
@@ -42,6 +42,7 @@ module Paperclip
         compressed_file.rewind
         dst.write(compressed_file.read)
         compressed_file.close
+        dst.rewind
         return dst
       else
         return @file

--- a/lib/paperclip-optimizer/processor.rb
+++ b/lib/paperclip-optimizer/processor.rb
@@ -2,7 +2,14 @@ require 'paperclip'
 require 'image_optim'
 
 module Paperclip
-  class PaperclipOptimizer < Processor  
+  class PaperclipOptimizer < Processor
+
+    def initialize(file, options = {}, attachment = nil)
+      super
+      @current_format = File.extname(@file.path)
+      @basename = File.basename(@file.path, @current_format)
+    end
+
     def self.default_options
       @default_options ||= ::PaperclipOptimizer::DEFAULT_OPTIONS
     end
@@ -13,6 +20,8 @@ module Paperclip
 
     def make
       src_path = File.expand_path(@file.path)
+      dst = Tempfile.new(@basename)
+      dst.binmode
 
       if optimizer_options[:verbose]
         Paperclip.logger.info "optimizing #{src_path} with settings: #{optimizer_options.inspect}"
@@ -29,10 +38,12 @@ module Paperclip
       end
 
       if compressed_file_path && File.exist?(compressed_file_path)
-        return File.open(compressed_file_path)
+        dst.write(compressed_file_path)
       else
-        return @file
+        dst.write(@file)
       end
+
+      dst
     end
 
       protected

--- a/lib/paperclip-optimizer/processor.rb
+++ b/lib/paperclip-optimizer/processor.rb
@@ -2,7 +2,7 @@ require 'paperclip'
 require 'image_optim'
 
 module Paperclip
-  class PaperclipOptimizer < Processor  
+  class PaperclipOptimizer < Processor
     def self.default_options
       @default_options ||= ::PaperclipOptimizer::DEFAULT_OPTIONS
     end
@@ -31,7 +31,7 @@ module Paperclip
       if compressed_file_path && File.exist?(compressed_file_path)
         return File.open(compressed_file_path)
       else
-        return @file
+        return File.new(@file.path)
       end
     end
 

--- a/lib/paperclip-optimizer/processor.rb
+++ b/lib/paperclip-optimizer/processor.rb
@@ -44,7 +44,7 @@ module Paperclip
         compressed_file.close
         return dst
       else
-        dst.write(@file)
+        return @file
       end
 
     end

--- a/lib/paperclip-optimizer/processor.rb
+++ b/lib/paperclip-optimizer/processor.rb
@@ -3,6 +3,13 @@ require 'image_optim'
 
 module Paperclip
   class PaperclipOptimizer < Processor
+
+    def initialize(file, options = {}, attachment = nil)
+      super
+      @current_format = File.extname(@file.path)
+      @basename = File.basename(@file.path, @current_format)
+    end
+
     def self.default_options
       @default_options ||= ::PaperclipOptimizer::DEFAULT_OPTIONS
     end
@@ -29,10 +36,17 @@ module Paperclip
       end
 
       if compressed_file_path && File.exist?(compressed_file_path)
-        return File.open(compressed_file_path)
+        dst = Tempfile.new(@basename)
+        dst.binmode
+        compressed_file = File.open(compressed_file_path)
+        compressed_file.rewind
+        dst.write(compressed_file.read)
+        compressed_file.close
+        return dst
       else
-        return File.new(@file.path)
+        return @file
       end
+
     end
 
       protected


### PR DESCRIPTION
Hi! since I include this processor in our flow, I being experiencing the return of errors randomly, like this one below:

```
An Errno::ENOENT occurred in background at 2015-02-02 20:49:32 UTC :

  No such file or directory - /tmp/83adcf1ccdc34521790435a27d35c13420150202-29204-19pmkse20150202-29204-17joo6a20150202-29204-kqducm
  /usr/lib64/ruby/1.9.1/fileutils.rb:1515:in `stat'

  -------------------------------
Backtrace:
-------------------------------

  /usr/lib64/ruby/1.9.1/fileutils.rb:1515:in `stat'
  /usr/lib64/ruby/1.9.1/fileutils.rb:1515:in `block in fu_each_src_dest'
  /usr/lib64/ruby/1.9.1/fileutils.rb:1531:in `fu_each_src_dest0'
  /usr/lib64/ruby/1.9.1/fileutils.rb:1513:in `fu_each_src_dest'
  /usr/lib64/ruby/1.9.1/fileutils.rb:395:in `cp'
  /data/shared/bundled_gems/ruby/1.9.1/gems/paperclip-4.2.1/lib/paperclip/io_adapters/abstract_adapter.rb:42:in `copy_to_tempfile'
  /data/shared/bundled_gems/ruby/1.9.1/gems/paperclip-4.2.1/lib/paperclip/io_adapters/file_adapter.rb:13:in `cache_current_values'
  /data/shared/bundled_gems/ruby/1.9.1/gems/paperclip-4.2.1/lib/paperclip/io_adapters/file_adapter.rb:5:in `initialize'
  /data/shared/bundled_gems/ruby/1.9.1/gems/paperclip-4.2.1/lib/paperclip/io_adapters/registry.rb:29:in `new'
  /data/shared/bundled_gems/ruby/1.9.1/gems/paperclip-4.2.1/lib/paperclip/io_adapters/registry.rb:29:in `for'
  /data/shared/bundled_gems/ruby/1.9.1/gems/paperclip-4.2.1/lib/paperclip/attachment.rb:528:in `post_process_style'
```

And I dig a lot to found the possible root of the problem, the thing is the way the [**make**](https://github.com/janfoeh/paperclip-optimizer/blob/master/lib/paperclip-optimizer/processor.rb#L14) method is implemented on this processor.
I change a few things in order to mimic the way the native [**Thumbnail**](https://github.com/thoughtbot/paperclip/blob/master/lib/paperclip/thumbnail.rb) processor work in paperclip, using the [**Tempfile**](http://ruby-doc.org//stdlib-1.9.3/libdoc/tempfile/rdoc/Tempfile.html) ruby library.

Since I change this I no longer get the error above.

Hope this helps, and please if there is anything else, or maybe if I miss something please don't hesitate to let me know!

Have a nice week!
